### PR TITLE
Persist login session and auto-login on register

### DIFF
--- a/gospel_frontend/lib/auth_screen.dart
+++ b/gospel_frontend/lib/auth_screen.dart
@@ -22,33 +22,30 @@ class _AuthScreenState extends State<AuthScreen> {
   String? error;
 
   Future<void> handleAuth() async {
-  if (!_formKey.currentState!.validate()) return;
+    if (!_formKey.currentState!.validate()) return;
 
-  try {
-    if (isLogin) {
-      await FirebaseAuth.instance.signInWithEmailAndPassword(
-        email: emailController.text.trim(),
-        password: passwordController.text.trim(),
-      );
-    } else {
-      final userCredential = await FirebaseAuth.instance.createUserWithEmailAndPassword(
-        email: emailController.text.trim(),
-        password: passwordController.text.trim(),
-      );
+    try {
+      if (isLogin) {
+        await FirebaseAuth.instance.signInWithEmailAndPassword(
+          email: emailController.text.trim(),
+          password: passwordController.text.trim(),
+        );
+      } else {
+        final userCredential =
+            await FirebaseAuth.instance.createUserWithEmailAndPassword(
+          email: emailController.text.trim(),
+          password: passwordController.text.trim(),
+        );
 
-      await FirebaseFirestore.instance
-          .collection('users')
-          .doc(userCredential.user!.uid)
-          .set({
-        'fullName': fullNameController.text.trim(),
-        'dob': dobController.text.trim(),
-        'email': emailController.text.trim(),
-      });
-    }
-
-    // 🔁 After successful login/registration
-    // ignore: use_build_context_synchronously
-      Navigator.of(context).pushReplacementNamed('/topics');
+        await FirebaseFirestore.instance
+            .collection('users')
+            .doc(userCredential.user!.uid)
+            .set({
+          'fullName': fullNameController.text.trim(),
+          'dob': dobController.text.trim(),
+          'email': emailController.text.trim(),
+        });
+      }
     } catch (e) {
       setState(() => error = e.toString());
     }

--- a/gospel_frontend/lib/main.dart
+++ b/gospel_frontend/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:gospel_frontend/auth_screen.dart';
 import 'package:gospel_frontend/main_scaffold.dart';
 import 'firebase_options.dart';
@@ -29,10 +30,20 @@ class GospelApp extends StatelessWidget {
         primarySwatch: Colors.blue,
         useMaterial3: true,
       ),
-      routes: {
-        '/': (_) => AuthScreen(),
-        '/topics': (_) => TopicListScreen()
-      },
+      home: StreamBuilder<User?>(
+        stream: FirebaseAuth.instance.authStateChanges(),
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Scaffold(
+              body: Center(child: CircularProgressIndicator()),
+            );
+          }
+          if (snapshot.hasData) {
+            return const TopicListScreen();
+          }
+          return const AuthScreen();
+        },
+      ),
     );
   }
 }

--- a/gospel_frontend/lib/main_scaffold.dart
+++ b/gospel_frontend/lib/main_scaffold.dart
@@ -35,7 +35,8 @@ class MainScaffold extends StatelessWidget {
                   if (value == 'logout') {
                     await FirebaseAuth.instance.signOut();
                     if (context.mounted) {
-                      Navigator.of(context).pushNamedAndRemoveUntil('/', (route) => false);
+                      Navigator.of(context)
+                          .popUntil((route) => route.isFirst);
                     }
                   }
                 },


### PR DESCRIPTION
## Summary
- Use FirebaseAuth authStateChanges stream to determine initial screen and maintain sessions across refreshes
- Remove manual navigation after auth and rely on stream-driven redirects
- Adjust logout flow to pop to root after sign out

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab08784e30832a8a2a29e1ded574e2