### PR TITLE
Maintain canonical gospel order in author selection

### DIFF
--- a/gospel_frontend/lib/main.dart
+++ b/gospel_frontend/lib/main.dart
@@ -243,7 +243,8 @@ class _ChooseAuthorScreenState extends State<ChooseAuthorScreen> {
     authors = widget.topic.references
         .map((e) => e['book'] as String)
         .toSet()
-        .toList();
+        .toList()
+      ..sort((a, b) => _gospelIndex(a).compareTo(_gospelIndex(b)));
   }
 
   @override


### PR DESCRIPTION
## Summary
- Sort `ChooseAuthorScreen` author list using canonical gospel order so the UI consistently displays Mathew, Mark, Luke, then John

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c136a26a9483299665566d47b5ef7d