### PR TITLE
Ensure Arabic→Arabic topic version switches load non-diacritized text

### DIFF
--- a/gospel_frontend/lib/main.dart
+++ b/gospel_frontend/lib/main.dart
@@ -5837,10 +5837,23 @@ class _AuthorComparisonScreenState extends State<AuthorComparisonScreen> {
   void _showTranslationChangePicker() {
     _showComparisonPicker(
       (language, version) async {
+        final sanitizedVersion = _sanitizeVersionForLanguage(language, version);
+        final forceArabicWithoutDiacritics =
+            _languageOption.code == 'arabic' && language.code == 'arabic';
+        final nextVersion = forceArabicWithoutDiacritics
+            ? (_resolveArabicVersion(
+                    language,
+                    withDiacritics: false,
+                    preferredVersion: sanitizedVersion) ??
+                sanitizedVersion)
+            : sanitizedVersion;
         setState(() {
           _languageOption = language;
-          _apiVersion = _sanitizeVersionForLanguage(language, version);
-          _withDiacritics = !_isArabicWithoutDiacritics(_apiVersion);
+          _apiVersion = nextVersion;
+          _withDiacritics = language.code == 'arabic'
+              ? !forceArabicWithoutDiacritics &&
+                  !_isArabicWithoutDiacritics(nextVersion)
+              : false;
         });
         LanguageSelectionController.instance.update(language.code);
         await _loadTopicForLanguage(language, _activeVersion);


### PR DESCRIPTION
### Motivation
- The topic page change-translation flow was loading diacritized Arabic text when switching between Arabic versions because `_sanitizeVersionForLanguage` inferred `withDiacritics` from the selected version string, causing the diacritized dataset to be resolved.  
- The intended behavior is that when the current language is Arabic and the user switches to another Arabic version, the app always loads the non-diacritized Arabic dataset.  

### Description
- In the topic page translation change handler (`_showTranslationChangePicker`) compute a `sanitizedVersion` and detect an Arabic→Arabic switch, then explicitly resolve the next version using `_resolveArabicVersion(... withDiacritics: false ...)` to force the non-diacritized dataset while preserving the selected Arabic base version.  
- Update state to set `_apiVersion` to the resolved `nextVersion` and ensure `_withDiacritics` is set so the UI/fetch layer uses the non-diacritized source for Arabic→Arabic switches.  
- The fix is localized to the topic translation change flow (not a UI-only patch) and leaves non-Arabic version handling unchanged.  

### Testing
- Ran `git diff` to inspect the applied change and confirmed the handler in `gospel_frontend/lib/main.dart` was updated as expected (succeeded).  
- Attempted to run `dart format` and `flutter test` but both failed in this environment because `dart`/`flutter` are not installed (automated runs unavailable).  
- Committed the change locally (`Fix Arabic topic translation switcher to keep non-diacritics`) and created this PR; no automated widget/unit tests were executed here due to missing SDKs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9349bab8883298ae73c3c3947906d)