### PR TITLE
Reset next-book navigation to chapter 1 on reference page

### DIFF
--- a/gospel_frontend/lib/main.dart
+++ b/gospel_frontend/lib/main.dart
@@ -3506,10 +3506,7 @@ class _ReferenceViewerPageState extends State<ReferenceViewerPage> {
               ? () => _openReferenceUri(
                   _referenceUri(
                       book: orderedGospels[bookIndex + 1],
-                      chapter: _clampChapterForBook(
-                        orderedGospels[bookIndex + 1],
-                        widget.chapter,
-                      ),
+                      chapter: 1,
                     ),
                 )
               : null,
@@ -3562,10 +3559,7 @@ class _ReferenceViewerPageState extends State<ReferenceViewerPage> {
               ? () => _openReferenceUri(
                   _referenceUri(
                       book: orderedGospels[bookIndex + 1],
-                      chapter: _clampChapterForBook(
-                        orderedGospels[bookIndex + 1],
-                        widget.chapter,
-                      ),
+                      chapter: 1,
                     ),
                 )
               : null,
@@ -4556,7 +4550,7 @@ class _ReferenceViewerPageState extends State<ReferenceViewerPage> {
           onNextBook: hasNextBook
               ? () => _openReferenceUri(_referenceUri(
                     book: orderedGospels[bookIndex + 1],
-                    chapter: _clampChapterForBook(orderedGospels[bookIndex + 1], widget.chapter),
+                    chapter: 1,
                   ))
               : null,
         ),
@@ -4593,7 +4587,7 @@ class _ReferenceViewerPageState extends State<ReferenceViewerPage> {
           onNextBook: hasNextBook
               ? () => _openReferenceUri(_referenceUri(
                     book: orderedGospels[bookIndex + 1],
-                    chapter: _clampChapterForBook(orderedGospels[bookIndex + 1], widget.chapter),
+                    chapter: 1,
                   ))
               : null,
         ),


### PR DESCRIPTION
### Motivation
- Fix reference-page navigation so "Next book" opens the destination book at its beginning (chapter 1, verse 1) and does not carry over any selected verse range/label from the current reference.

### Description
- Updated the `onNextBook` handlers in `gospel_frontend/lib/main.dart` to pass `chapter: 1` (replacing the previous `_clampChapterForBook(..., widget.chapter)`), applied in both duplicated chapter-nav render paths so next-book always routes to chapter 1 while preserving `language`/`version` via the existing `_referenceUri` logic.

### Testing
- Attempted to run `dart format` and `flutter test` but both SDK tools are not available in this environment (`dart: command not found` and `flutter: command not found`), so no automated tests were executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbd8208158832996a4c2e8abd8274c)